### PR TITLE
Add author's name and avatar to poll embed author attribute

### DIFF
--- a/modules/polls.rb
+++ b/modules/polls.rb
@@ -34,6 +34,10 @@ module Polls
     bot_user = event.bot.bot_user
 
     embed_msg = channel.send_embed do |m|
+      m.author = {
+        icon_url: event.author.avatar_url,
+        name: event.author.username
+      }
       m.title = title
       m.description = opts.map.with_index do |arg, idx|
         ":#{to_word(idx + 1)}:#{"\u00A0" * 3}#{arg}"


### PR DESCRIPTION
Please be gentle this is my first ruby commit...

This does exactly as the title says, it adds the author's name and avatar to the author attribute of the poll embed. This is useful for actually seeing who created the poll, especially on servers without logs.

Yes, I probably could've made an issue instead because of how short it is, but I didn't because I'm bored today.